### PR TITLE
Fix ticket notification test where clicking on email link was broken

### DIFF
--- a/features/ticket_notifications.feature
+++ b/features/ticket_notifications.feature
@@ -30,7 +30,7 @@ Feature: Ticket notifications
     Then "alice@ticketee.com" should receive an email
     When "alice@ticketee.com" opens the email
     Then they should see "updated the Release date ticket" in the email body
-    Then they click the first link in the email
+    Then they follow "view this ticket online here" in the email
     Then I should be on the "Release date" ticket in the "TextMate 2" project
   
   Scenario: Comment authors are automatically subscribed to a ticket


### PR DESCRIPTION
This commit fixes a broken test in the ticket notifications feature in the scenario "Ticket owner is automatically subscribed to a ticket"

When an email was sent for it included a link to an image (the logo) as well as a link to the ticket.

The cucumber feature was attempting to click the link to the ticket `Then they click the first link in the email`. It turns out that this was opening the image (logo) url instead of the ticket link. It might be a bug with email-spec. 

A simple fix to the problem is to explicitly name the link that we are trying to click with `Then they follow "view this ticket online here" in the email`.
